### PR TITLE
Improve mobile layout for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
               <path d="M6 6h15l-1.5 9h-12z"/><circle cx="9" cy="20" r="1.5"/><circle cx="17" cy="20" r="1.5"/>
               <path d="M6 6l-2-2H2"/>
             </svg>
-            Giỏ hàng
+            <span class="label">Giỏ hàng</span>
           </button>
         </div>
       </nav>

--- a/styles.css
+++ b/styles.css
@@ -34,8 +34,7 @@ nav{display:flex;align-items:center;justify-content:space-between}
 .filter-bar{display:flex;align-items:center;justify-content:space-between;border-top:1px solid var(--line);border-bottom:1px solid var(--line);padding:10px 0;margin-top:12px}
 .small{font-size:12px;color:var(--muted)}
 
-.grid{display:grid;gap:24px;padding:24px 20px;grid-template-columns:1fr}
-@media(min-width:600px){.grid{grid-template-columns:repeat(2,1fr)}}
+.grid{display:grid;gap:24px;padding:24px 20px;grid-template-columns:repeat(2,1fr)}
 @media(min-width:900px){.grid{grid-template-columns:repeat(4,1fr)}}
 .checkout-layout{display:grid;gap:18px;grid-template-columns:1fr 1fr}
 .two-col{display:grid;gap:12px;grid-template-columns:1fr 1fr}
@@ -66,8 +65,12 @@ nav{display:flex;align-items:center;justify-content:space-between}
 .badge{display:inline-block;border:1px solid var(--line);padding:4px 8px;border-radius:999px;font-size:11px;margin-left:8px}
 
 @media(max-width:600px){
-  nav{flex-direction:column;align-items:flex-start;gap:12px}
-  .nav-links{flex-wrap:wrap;gap:12px}
+  nav{flex-direction:row;align-items:center;justify-content:space-between}
+  .nav-links{display:none}
+  .brand{flex:1;justify-content:center}
+  .brand h1{display:none}
+  .cart-button{border:none;padding:0}
+  .cart-button .label{display:none}
   .page-title{font-size:32px}
   .checkout-layout{grid-template-columns:1fr}
   .two-col{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- simplify mobile header with centered logo and hidden navigation links
- adjust product grid to show two columns on phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2b0f9c60c8326977dcfa3a3b2e8f6