### PR TITLE
Improve mobile menu and add product detail modal

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -54,7 +54,7 @@ function renderGrid(){
   if(!el) return;
   el.innerHTML = products.map(p => `
     <article class="card">
-      <div class="imgwrap"><img src="${p.image}" alt="${p.name}" loading="lazy"></div>
+      <div class="imgwrap" onclick="showProductDetail('${p.id}')"><img src="${p.image}" alt="${p.name}" loading="lazy"></div>
       <h3 class="title">${p.name}</h3>
       <div class="price">From ${formatCurrency(p.price)}</div>
       <div class="size-row">
@@ -101,9 +101,31 @@ function openDrawer(){
   document.getElementById('drawer').classList.add('open'); 
   document.getElementById('overlay').classList.add('open'); 
 }
-function closeDrawer(){ 
-  document.getElementById('drawer').classList.remove('open'); 
-  document.getElementById('overlay').classList.remove('open'); 
+function closeDrawer(){
+  document.getElementById('drawer').classList.remove('open');
+  document.getElementById('overlay').classList.remove('open');
+}
+
+function showProductDetail(id){
+  const p = products.find(x=>x.id===id);
+  if(!p) return;
+  const img = document.getElementById('detailImage');
+  const name = document.getElementById('detailName');
+  const price = document.getElementById('detailPrice');
+  const sizes = document.getElementById('detailSizes');
+  if(!img || !name || !price || !sizes) return;
+  img.src = p.image;
+  img.alt = p.name;
+  name.textContent = p.name;
+  price.textContent = formatCurrency(p.price);
+  sizes.innerHTML = p.sizes.map(s => `<button class="size-btn" onclick="addToCart('${p.id}','${s}')">${s}</button>`).join('');
+  document.getElementById('productModal').classList.add('open');
+  document.getElementById('productOverlay').classList.add('open');
+}
+
+function closeProductModal(){
+  document.getElementById('productModal').classList.remove('open');
+  document.getElementById('productOverlay').classList.remove('open');
 }
 
 function getOrderFromStorage(){
@@ -149,4 +171,6 @@ if(document.getElementById('openCart')){
   document.getElementById('overlay').addEventListener('click', closeDrawer);
   renderGrid();
   renderCart();
+  document.getElementById('closeProduct').addEventListener('click', closeProductModal);
+  document.getElementById('productOverlay').addEventListener('click', closeProductModal);
 }

--- a/index.html
+++ b/index.html
@@ -11,16 +11,17 @@
   <header>
     <div class="container">
       <nav>
+        <div class="brand">
+          <img class="brand-logo" src="logo.png" alt="Kadie.Nuwrld logo">
+          <h1>KADIE.NUWRLD</h1>
+        </div>
         <button class="menu-button" id="menuBtn">
           <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path d="M3 6h18M3 12h18M3 18h18"/>
           </svg>
         </button>
-        <div class="brand">
-          <img class="brand-logo" src="logo.png" alt="Kadie.Nuwrld logo">
-          <h1>KADIE.NUWRLD</h1>
-        </div>
         <div class="nav-links" id="navLinks">
+          <button class="close-menu" id="closeMenu">&times;</button>
           <a class="nav-link" href="#">.STUDIOS</a>
           <a class="nav-link" href="#">CAPSULE</a>
           <a class="nav-link" href="#">SPORTS</a>
@@ -58,7 +59,7 @@
   <aside class="drawer" id="drawer">
     <header>
       <strong>Giỏ hàng</strong>
-      <button class="cart-button" id="closeCart">Đóng</button>
+      <button class="cart-button" id="closeCart">&times;</button>
     </header>
     <div class="items" id="cartItems"></div>
     <div class="subtotal">
@@ -71,13 +72,26 @@
     <a class="checkout" href="checkout.html">Thanh toán →</a>
   </aside>
 
+  <div class="product-overlay" id="productOverlay"></div>
+  <div class="product-modal" id="productModal">
+    <button class="close-product" id="closeProduct">&times;</button>
+    <img id="detailImage" src="" alt="">
+    <h3 id="detailName"></h3>
+    <div id="detailPrice"></div>
+    <div class="size-row" id="detailSizes"></div>
+  </div>
+
   <script src="cart.js"></script>
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
     const menuBtn = document.getElementById('menuBtn');
     const navLinks = document.getElementById('navLinks');
+    const closeMenu = document.getElementById('closeMenu');
     menuBtn.addEventListener('click', () => {
       navLinks.classList.toggle('open');
+    });
+    closeMenu.addEventListener('click', () => {
+      navLinks.classList.remove('open');
     });
   </script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,7 @@ nav{display:flex;align-items:center}
 .brand h1{font-size:18px;letter-spacing:.24em;margin:0}
 
 .nav-links{display:flex;gap:26px;align-items:center;margin-left:auto}
+.close-menu{display:none;background:none;border:none;font-size:24px;cursor:pointer;margin-left:auto}
 .nav-link{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:#000000}
 .cart-button{
   display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);background:#fff;padding:8px 12px;border-radius:999px;cursor:pointer
@@ -67,16 +68,27 @@ nav > .cart-button{margin-left:16px}
 .checkout{margin:0 16px 14px 16px;padding:12px;border:1px solid var(--line);border-radius:14px;background:#111;color:#fff;cursor:pointer;text-align:center}
 .badge{display:inline-block;border:1px solid var(--line);padding:4px 8px;border-radius:999px;font-size:11px;margin-left:8px}
 
+.product-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);opacity:0;pointer-events:none;transition:.2s}
+.product-overlay.open{opacity:1;pointer-events:auto}
+.product-modal{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;border:1px solid var(--line);border-radius:12px;padding:20px;width:90%;max-width:400px;max-height:90%;overflow:auto;opacity:0;pointer-events:none;transition:.2s}
+.product-modal.open{opacity:1;pointer-events:auto}
+.product-modal img{border:1px solid var(--line);border-radius:8px;margin-bottom:12px}
+.product-modal .close-product{position:absolute;top:8px;right:8px;background:none;border:none;font-size:24px;cursor:pointer}
+.product-modal h3{margin:0 0 8px 0}
+.product-modal #detailPrice{margin-bottom:12px}
+
 @media(max-width:600px){
   nav{position:relative}
-  .menu-button{display:flex;align-items:center;justify-content:center}
-  .nav-links{display:none;position:absolute;top:100%;left:0;right:0;background:#fff;flex-direction:column;gap:16px;padding:16px;border-bottom:1px solid var(--line)}
+  .menu-button{display:flex;align-items:center;justify-content:center;margin-left:auto}
+  .nav-links{display:none;position:absolute;top:100%;left:0;right:0;background:#fff;flex-direction:column;gap:16px;padding:16px;border-bottom:1px solid var(--line);align-items:flex-start}
   .nav-links.open{display:flex}
-  .brand{flex:1;justify-content:center}
+  .close-menu{display:block}
+  .brand{justify-content:flex-start;margin-right:auto}
+  .brand-logo{width:60px;height:60px}
   .brand h1{display:none}
-  .cart-button{border:none;padding:0;margin-left:0}
+  .cart-button{border:none;padding:0;margin-left:8px}
   .cart-button .label{display:none}
-  nav > .cart-button{margin-left:0}
+  nav > .cart-button{margin-left:8px}
   .grid{display:flex;overflow-x:auto;gap:16px;padding:24px 20px}
   .grid .card{flex:0 0 80%}
   .page-title{font-size:32px}


### PR DESCRIPTION
## Summary
- Reorder header and add close button for mobile menu
- Enlarge logo on phones and add X button for cart and menu
- Enable product detail modal when tapping product images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2e1d659f48326a6120ccfbee16279