### PR TITLE
feat: enhance mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,23 @@
     © <span id="y"></span> Kadie.Nuwrld · Static shop (COD + MoMo)
   </footer>
 
+  <button class="mobile-menu-button" id="openMobileMenu">
+    <img src="logo.png" alt="Kadie.Nuwrld logo">
+  </button>
+  <div class="mobile-menu" id="mobileMenu">
+    <header>
+      <img src="logo.png" alt="Kadie.Nuwrld logo">
+      <button class="close-mobile-menu" id="closeMobileMenu">&times;</button>
+    </header>
+    <nav class="menu-links">
+      <a href="#" class="active">Studios</a>
+      <a href="#">Capsule</a>
+      <a href="#">Sports</a>
+      <a href="#">Log in</a>
+      <a href="#">Create account</a>
+    </nav>
+  </div>
+
   <div class="drawer-overlay" id="overlay"></div>
   <aside class="drawer" id="drawer">
     <header>
@@ -93,6 +110,18 @@
     closeMenu.addEventListener('click', () => {
       navLinks.classList.remove('open');
     });
+
+    const openMobileMenu = document.getElementById('openMobileMenu');
+    const mobileMenu = document.getElementById('mobileMenu');
+    const closeMobileMenu = document.getElementById('closeMobileMenu');
+    if(openMobileMenu){
+      openMobileMenu.addEventListener('click', () => {
+        mobileMenu.classList.add('open');
+      });
+      closeMobileMenu.addEventListener('click', () => {
+        mobileMenu.classList.remove('open');
+      });
+    }
   </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -33,6 +33,9 @@ nav{display:flex;align-items:center}
 nav > .cart-button{margin-left:16px}
 .icon{width:18px;height:18px;display:inline-block}
 
+.mobile-menu-button,
+.mobile-menu{display:none}
+
 .hero{padding:42px 20px 8px 20px;}
 .page-title{font-size:42px;letter-spacing:.18em;text-transform:uppercase;margin:0 0 8px 0;font-weight:800}
 .filter-bar{display:flex;align-items:center;justify-content:space-between;border-top:1px solid var(--line);border-bottom:1px solid var(--line);padding:10px 0;margin-top:12px}
@@ -78,20 +81,30 @@ nav > .cart-button{margin-left:16px}
 .product-modal #detailPrice{margin-bottom:12px}
 
 @media(max-width:600px){
-  nav{position:relative}
-  .menu-button{display:flex;align-items:center;justify-content:center;margin-left:auto}
-  .nav-links{display:none;position:absolute;top:100%;left:0;right:0;background:#fff;flex-direction:column;gap:16px;padding:16px;border-bottom:1px solid var(--line);align-items:flex-start}
-  .nav-links.open{display:flex}
-  .close-menu{display:block}
-  .brand{justify-content:flex-start;margin-right:auto}
-  .brand-logo{width:60px;height:60px}
+  nav{position:relative;justify-content:center}
+  .menu-button{display:none}
+  .nav-links{display:none!important}
+  .nav-links.open{display:none}
+  .close-menu{display:none}
+  .brand{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);margin:0}
+  .brand-logo{width:80px;height:80px}
   .brand h1{display:none}
-  .cart-button{border:none;padding:0;margin-left:8px}
+  .cart-button{border:none;padding:0;position:absolute;right:0;top:50%;transform:translateY(-50%)}
   .cart-button .label{display:none}
-  nav > .cart-button{margin-left:8px}
+  nav > .cart-button{margin-left:0}
   .grid{display:flex;overflow-x:auto;gap:16px;padding:24px 20px}
   .grid .card{flex:0 0 80%}
   .page-title{font-size:32px}
   .checkout-layout{grid-template-columns:1fr}
   .two-col{grid-template-columns:1fr}
+
+  .mobile-menu-button{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);width:72px;height:72px;border:1px solid var(--text);border-radius:50%;background:#fff;display:flex;align-items:center;justify-content:center;z-index:20}
+  .mobile-menu-button img{width:60px;height:60px;border-radius:50%;object-fit:cover}
+  .mobile-menu{position:fixed;inset:0;background:#fff;display:none;flex-direction:column;padding:16px;z-index:30}
+  .mobile-menu.open{display:flex}
+  .mobile-menu header{display:flex;justify-content:space-between;align-items:center;margin-bottom:24px}
+  .mobile-menu header img{width:60px;height:60px;border-radius:50%;border:1px solid var(--text)}
+  .close-mobile-menu{background:none;border:none;font-size:28px;cursor:pointer}
+  .menu-links{display:flex;flex-direction:column;gap:16px;font-size:18px}
+  .menu-links a.active{background:#d8f0ff}
 }


### PR DESCRIPTION
## Summary
- enlarge mobile header logo and remove desktop links for small screens
- add floating logo button with full-screen menu overlay
- wire up JavaScript handlers for new mobile navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2e8c9f0c08326bf5cae5b963e3192