### PR TITLE
feat: improve mobile header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,11 +11,11 @@
   <header>
     <div class="container">
       <nav>
-        <div class="brand">
+        <a class="brand" href="index.html">
           <img class="brand-logo" src="logo.png" alt="Kadie.Nuwrld logo">
           <h1>KADIE.NUWRLD</h1>
-        </div>
-        <button class="menu-button" id="menuBtn">
+        </a>
+        <button class="menu-button" id="menuBtn" aria-label="Menu">
           <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
             <path d="M3 6h18M3 12h18M3 18h18"/>
           </svg>
@@ -104,15 +104,19 @@
     const menuBtn = document.getElementById('menuBtn');
     const navLinks = document.getElementById('navLinks');
     const closeMenu = document.getElementById('closeMenu');
+    const mobileMenu = document.getElementById('mobileMenu');
     menuBtn.addEventListener('click', () => {
-      navLinks.classList.toggle('open');
+      if(window.innerWidth <= 600){
+        mobileMenu.classList.add('open');
+      } else {
+        navLinks.classList.toggle('open');
+      }
     });
     closeMenu.addEventListener('click', () => {
       navLinks.classList.remove('open');
     });
 
     const openMobileMenu = document.getElementById('openMobileMenu');
-    const mobileMenu = document.getElementById('mobileMenu');
     const closeMobileMenu = document.getElementById('closeMobileMenu');
     if(openMobileMenu){
       openMobileMenu.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -82,12 +82,12 @@ nav > .cart-button{margin-left:16px}
 
 @media(max-width:600px){
   nav{position:relative;justify-content:center}
-  .menu-button{display:none}
+  .menu-button{display:block;position:absolute;left:0;top:50%;transform:translateY(-50%);background:none;border:none;padding:0}
   .nav-links{display:none!important}
   .nav-links.open{display:none}
   .close-menu{display:none}
   .brand{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);margin:0}
-  .brand-logo{width:80px;height:80px}
+  .brand-logo{width:60px;height:60px}
   .brand h1{display:none}
   .cart-button{border:none;padding:0;position:absolute;right:0;top:50%;transform:translateY(-50%)}
   .cart-button .label{display:none}


### PR DESCRIPTION
## Summary
- center logo in mobile header
- show hamburger menu button and hook it up to the mobile menu
- allow logo click to return to homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a2eeca4e808326905fd94296a95d50