### PR TITLE
feat: refine mobile header design

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -67,9 +67,14 @@ function renderGrid(){
 function renderCart(){
   const itemsEl = document.getElementById('cartItems');
   const subtotalEl = document.getElementById('subtotal');
+  const countEl = document.getElementById('cartCount');
   if(!itemsEl || !subtotalEl) return;
 
   const cart = loadCart();
+  if(countEl){
+    const count = cart.items.reduce((s,i)=>s+i.qty,0);
+    countEl.style.display = count>0 ? 'block' : 'none';
+  }
   if(cart.items.length===0){
     itemsEl.innerHTML = `<p class="small">Giỏ trống.</p>`;
     subtotalEl.textContent = '0₫';

--- a/checkout.html
+++ b/checkout.html
@@ -11,7 +11,7 @@
     <div class="container">
       <nav>
         <div class="brand">
-          <img class="brand-logo" src="logo.png" alt="Kadie.Nuwrld logo">
+          <img class="brand-mark" src="logo.png" alt="Kadie.Nuwrld logo">
           <h1>CHECKOUT</h1>
           <span class="badge">COD + MoMo</span>
         </div>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,11 @@
     <div class="container">
       <nav>
         <a class="brand" href="index.html">
-          <img class="brand-logo" src="logo.png" alt="Kadie.Nuwrld logo">
+          <img class="brand-mark" src="logo.png" alt="Kadie.Nuwrld logo">
           <h1>KADIE.NUWRLD</h1>
         </a>
         <button class="menu-button" id="menuBtn" aria-label="Menu">
-          <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
             <path d="M3 6h18M3 12h18M3 18h18"/>
           </svg>
         </button>
@@ -27,11 +27,12 @@
           <a class="nav-link" href="#">SPORTS</a>
         </div>
         <button class="cart-button" id="openCart">
-          <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M6 6h15l-1.5 9h-12z"/><circle cx="9" cy="20" r="1.5"/><circle cx="17" cy="20" r="1.5"/>
             <path d="M6 6l-2-2H2"/>
           </svg>
           <span class="label">Giỏ hàng</span>
+          <span class="cart-badge" id="cartCount"></span>
         </button>
       </nav>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -12,14 +12,13 @@ img{max-width:100%;display:block}
 a{color:inherit;text-decoration:none}
 
 header{
-  position:sticky;top:0;z-index:10;background:rgba(255,255,255,.85);backdrop-filter:saturate(180%) blur(8px);
-  border-bottom:1px solid var(--line);
+  position:sticky;top:0;z-index:10;background:#fff;border-bottom:1px solid var(--line);
 }
 .container{max-width:1280px;margin:0 auto;padding:20px}
 
 nav{display:flex;align-items:center}
 .brand{display:flex;align-items:center;gap:12px}
-.brand-logo{width:36px;height:36px;border-radius:999px;border:1px solid var(--text);object-fit:cover}
+.brand-mark{width:36px;height:36px;border-radius:999px;border:1px solid var(--text);object-fit:cover}
 .menu-button{background:none;border:none;padding:0;display:none;cursor:pointer}
 .menu-button .icon{width:24px;height:24px}
 .brand h1{font-size:18px;letter-spacing:.24em;margin:0}
@@ -31,7 +30,9 @@ nav{display:flex;align-items:center}
   display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);background:#fff;padding:8px 12px;border-radius:999px;cursor:pointer
 }
 nav > .cart-button{margin-left:16px}
-.icon{width:18px;height:18px;display:inline-block}
+.icon{width:18px;height:18px;display:inline-block;stroke-width:1.5}
+
+.cart-badge{position:absolute;top:4px;right:4px;width:8px;height:8px;background:#ff3b30;border-radius:50%;display:none}
 
 .mobile-menu{display:none}
 
@@ -81,16 +82,22 @@ nav > .cart-button{margin-left:16px}
 
 @media(max-width:600px){
   nav{position:relative;justify-content:center}
-  .menu-button{display:block;position:absolute;left:0;top:50%;transform:translateY(-50%);background:none;border:none;padding:0}
+  .menu-button,
+  nav > .cart-button{
+    position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:1px solid var(--text);border-radius:50%;background:#fff;padding:0;display:flex;align-items:center;justify-content:center;
+  }
+  .menu-button{left:0;display:flex}
+  nav > .cart-button{right:0;margin-left:0}
+  .menu-button .icon,
+  nav > .cart-button .icon{width:24px;height:24px}
   .nav-links{display:none!important}
   .nav-links.open{display:none}
   .close-menu{display:none}
   .brand{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);margin:0}
-  .brand-logo{width:60px;height:60px}
+  .brand-mark{width:56px;height:56px}
   .brand h1{display:none}
-  .cart-button{border:none;padding:0;position:absolute;right:0;top:50%;transform:translateY(-50%)}
-  .cart-button .label{display:none}
-  nav > .cart-button{margin-left:0}
+  nav > .cart-button .label{display:none}
+  .hero{padding-top:96px}
   .grid{display:flex;overflow-x:auto;gap:16px;padding:24px 20px}
   .grid .card{flex:0 0 80%}
   .page-title{font-size:32px}


### PR DESCRIPTION
## Summary
- Center mobile header logo with 56px circular brand mark
- Style hamburger and cart buttons as 44px black-outlined icons with thin stroke
- Add cart badge indicator and ensure sticky white header with breathing room

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5718a46a083268cbfa69d9487cf09