### PR TITLE
Refine header layout and assets

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -2,10 +2,10 @@
 const LS_KEY = 'kadie_cart';
 
 const products = [
-  {id:'kadie-hoodie', name:'Kadie.Nuwrld Classic Hoodie', price: 650000, image:'assets/p1.jng', sizes:['S','M','L']},
-  {id:'kadie-sweatpants', name:'Kadie.Nuwrld Classic Sweatpants', price: 479000, image:'assets/p2.jng', sizes:['S','M','L']},
-  {id:'classic-tee-green', name:'Classic T‑Shirt — Green', price: 349000, image:'assets/p3.jng', sizes:['S','M','L']},
-  {id:'classic-tee-orange', name:'Classic T‑Shirt — Orange', price: 349000, image:'assets/p4.jng', sizes:['S','M','L']},
+  {id:'kadie-hoodie', name:'Kadie.Nuwrld Classic Hoodie', price: 650000, image:'assets/p1.png', sizes:['S','M','L']},
+  {id:'kadie-sweatpants', name:'Kadie.Nuwrld Classic Sweatpants', price: 479000, image:'assets/p2.png', sizes:['S','M','L']},
+  {id:'classic-tee-green', name:'Classic T‑Shirt — Green', price: 349000, image:'assets/p3.png', sizes:['S','M','L']},
+  {id:'classic-tee-orange', name:'Classic T‑Shirt — Orange', price: 349000, image:'assets/p4.png', sizes:['S','M','L']},
 ];
 
 function formatCurrency(v){

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
       <nav>
         <a class="brand" href="index.html">
           <img class="brand-mark" src="logo.png" alt="Kadie.Nuwrld logo">
-          <h1>KADIE.NUWRLD</h1>
         </a>
         <button class="menu-button" id="menuBtn" aria-label="Menu">
           <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
@@ -32,7 +31,6 @@
             <path d="M6 6l-2-2H2"/>
           </svg>
           <span class="label">Giỏ hàng</span>
-          <span class="cart-badge" id="cartCount"></span>
         </button>
       </nav>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -16,23 +16,21 @@ header{
 }
 .container{max-width:1280px;margin:0 auto;padding:20px}
 
-nav{display:grid;grid-template-columns:1fr auto 1fr;align-items:center}
+nav{display:flex;align-items:center}
 .brand{display:flex;align-items:center;gap:12px}
-.brand-mark{width:36px;height:36px;border-radius:999px;border:1px solid var(--text);object-fit:cover}
+.brand-mark{height:36px;width:auto;object-fit:contain}
 .menu-button{background:none;border:none;padding:0;display:none;cursor:pointer}
 .menu-button .icon{width:24px;height:24px}
 .brand h1{font-size:18px;letter-spacing:.24em;margin:0}
 
-.nav-links{display:flex;gap:26px;align-items:center;justify-content:center}
+.nav-links{display:flex;gap:26px;align-items:center;justify-content:flex-end;margin-left:auto}
 .close-menu{display:none;background:none;border:none;font-size:24px;cursor:pointer;margin-left:auto}
 .nav-link{font-size:12px;letter-spacing:.2em;text-transform:uppercase;color:#000000}
 .cart-button{
   display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);background:#fff;padding:8px 12px;border-radius:999px;cursor:pointer
 }
-nav > .cart-button{justify-self:end}
+nav > .cart-button{margin-left:16px}
 .icon{width:18px;height:18px;display:inline-block;stroke-width:1.5}
-
-.cart-badge{position:absolute;top:4px;right:4px;width:8px;height:8px;background:#ff3b30;border-radius:50%;display:none}
 
 .mobile-menu{display:none}
 
@@ -84,7 +82,7 @@ nav > .cart-button{justify-self:end}
   nav{position:relative;justify-content:center;display:flex}
   .menu-button,
   nav > .cart-button{
-    position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:1px solid var(--text);border-radius:50%;background:#fff;padding:0;display:flex;align-items:center;justify-content:center;
+    position:absolute;top:50%;transform:translateY(-50%);width:44px;height:44px;border:none;border-radius:0;background:none;padding:0;display:flex;align-items:center;justify-content:center;
   }
   .menu-button{left:0;display:flex}
   nav > .cart-button{right:0;margin-left:0}
@@ -94,7 +92,7 @@ nav > .cart-button{justify-self:end}
   .nav-links.open{display:none}
   .close-menu{display:none}
   .brand{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);margin:0}
-  .brand-mark{width:56px;height:56px}
+  .brand-mark{height:56px;width:auto;border:none;border-radius:0;object-fit:contain}
   .brand h1{display:none}
   nav > .cart-button .label{display:none}
   .hero{padding-top:96px}
@@ -107,7 +105,7 @@ nav > .cart-button{justify-self:end}
   .mobile-menu{position:fixed;inset:0;background:#fff;display:none;flex-direction:column;padding:16px;z-index:30}
   .mobile-menu.open{display:flex}
   .mobile-menu header{display:flex;justify-content:space-between;align-items:center;margin-bottom:24px}
-  .mobile-menu header img{width:60px;height:60px;border-radius:50%;border:1px solid var(--text)}
+  .mobile-menu header img{height:60px;width:auto;border:none;border-radius:0;object-fit:contain}
   .close-mobile-menu{background:none;border:none;font-size:28px;cursor:pointer}
   .menu-links{display:flex;flex-direction:column;gap:16px;font-size:18px}
   .menu-links a.active{background:#d8f0ff}


### PR DESCRIPTION
## Summary
- Remove cart badge and brand text so header shows only the logo with navigation right-aligned
- Strip mobile menu/cart button borders and show full logo imagery
- Update product image paths to new `.png` files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a587b785bc83268360a8fa02df31e6