### PR TITLE
Increase mobile header logo spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -180,8 +180,8 @@ nav > .cart-button{margin-left:16px}
   :root{
     --logo-size:120px;
     /* tuỳ ý tinh chỉnh riêng trên mobile */
-    --header-pad-top: 16px;
-    --header-pad-bottom: 12px;
+    --header-pad-top: 100px;
+    --header-pad-bottom: 100px;
   }
 }
 


### PR DESCRIPTION
## Summary
- expand mobile header padding above and below the logo to 100px for more breathing room

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a5c91e7c40832680a0f66f2377c121