### PR TITLE
Fix mobile overlays and show cart quantity

### DIFF
--- a/cart.js
+++ b/cart.js
@@ -90,7 +90,8 @@ function saveCart() {
 const cartCountEl = qs('#cartCount');
 
 // Cho phép các file khác gọi updateCartCount (nếu cần)
-window.updateCartCount = function (n) {
+// n mặc định = tổng hiện tại trong giỏ
+window.updateCartCount = function (n = getCartCount()) {
   if (!cartCountEl) return;
   cartCountEl.textContent = n;
   cartCountEl.style.display = n > 0 ? 'inline-block' : 'none';

--- a/styles.css
+++ b/styles.css
@@ -70,8 +70,9 @@ nav > .cart-button{margin-left:16px}
 
 .footer{border-top:1px solid var(--line);padding:24px;color:var(--muted);text-align:center}
 
-.drawer-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);opacity:0;pointer-events:none;transition:.2s}
-.drawer{position:fixed;top:0;right:-420px;width:100%;max-width:420px;height:100%;background:#fff;border-left:1px solid var(--line);transition:right .25s ease;display:flex;flex-direction:column}
+  /* Cart drawer overlays entire viewport */
+  .drawer-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);opacity:0;pointer-events:none;transition:.2s;z-index:2000}
+  .drawer{position:fixed;top:0;right:-420px;width:100%;max-width:420px;height:100%;background:#fff;border-left:1px solid var(--line);transition:right .25s ease;display:flex;flex-direction:column;z-index:2001}
 .drawer.open{right:0}
 .drawer-overlay.open{opacity:1;pointer-events:auto}
 .drawer header{display:flex;justify-content:space-between;align-items:center;padding:16px;border-bottom:1px solid var(--line)}
@@ -106,7 +107,8 @@ nav > .cart-button{margin-left:16px}
   .checkout-layout{grid-template-columns:1fr}
   .two-col{grid-template-columns:1fr}
 
-  .mobile-menu{position:fixed;inset:0;background:#fff;display:none;flex-direction:column;padding:16px;z-index:30}
+  /* Mobile menu as full-screen overlay above header */
+  .mobile-menu{position:fixed;inset:0;background:#fff;display:none;flex-direction:column;padding:16px;z-index:2000}
   .mobile-menu.open{display:flex}
   .mobile-menu header{display:flex;justify-content:space-between;align-items:center;margin-bottom:24px}
   .mobile-menu header img{height:60px;width:auto;border:none;border-radius:0;object-fit:contain}


### PR DESCRIPTION
## Summary
- Ensure mobile menu and cart drawer overlay the header on phones
- Make cart count badge default to current quantity

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a6a53fad348326ab0ced0c3ac49cec