### PR TITLE
Normalize image paths on checkout page

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -83,17 +83,17 @@
     if(order.items.length===0){
       sumEl.innerHTML = '<p class="small">Giỏ hàng trống. <a href="index.html">Mua hàng</a></p>';
     }else{
-      sumEl.innerHTML = order.items.map(item => `
-        <div class="line">
-          <img src="${item.image}" alt="${item.name}">
-          <div class="meta">
-            <div><strong>${item.name}</strong></div>
-            <div class="small">Size: ${item.size || '-'}</div>
-            <div class="small">x${item.qty}</div>
+        sumEl.innerHTML = order.items.map(item => `
+          <div class="line">
+            <img src="${item.image.replace(/^(\.\.\/)+/, '')}" alt="${item.name}">
+            <div class="meta">
+              <div><strong>${item.name}</strong></div>
+              <div class="small">Size: ${item.size || '-'}</div>
+              <div class="small">x${item.qty}</div>
+            </div>
+            <div><strong>${formatCurrency(item.price*item.qty)}</strong></div>
           </div>
-          <div><strong>${formatCurrency(item.price*item.qty)}</strong></div>
-        </div>
-      `).join('');
+        `).join('');
     }
     document.getElementById('grandTotal').textContent = formatCurrency(order.total);
 


### PR DESCRIPTION
## Summary
- Ensure checkout summary strips parent directory prefixes from item images to render PNGs reliably

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a6fcdef2bc832685d69cb81dfa2586